### PR TITLE
Added method so that a channel does not have to be provided

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,22 @@ app.get('/', (req, res) => {
   res.send('DockerHub2Slack Webhooks http://github.com/chamerling/dockerhub2slack');
 });
 
+app.post('/webhook', (req, res) => {
+  if (!req.body) {
+    return res.status(400).send();
+  }
+
+  let msg = `Docker Repository ${req.body.repository.repo_name}:${req.body.push_data.tag} updated by ${req.body.push_data.pusher}`;
+
+  let channel = ''
+  client.sendMessage(channel, msg, [req.body.repository.repo_url], (err) => {
+    if (err) {
+      console.log('Error while sending message to slack', err);
+    }
+    res.status(200).send('ok');
+  });
+});
+
 app.post('/webhook/:channelName', (req, res) => {
   let channel = req.params.channelName || DEFAULT_CHANNEL;
 

--- a/server/index.js
+++ b/server/index.js
@@ -20,20 +20,24 @@ app.get('/', (req, res) => {
   res.send('DockerHub2Slack Webhooks http://github.com/chamerling/dockerhub2slack');
 });
 
-app.post('/webhook', (req, res) => {
-  if (!req.body) {
-    return res.status(400).send();
-  }
-
+function processWebhook(channel, req, res){
   let msg = `Docker Repository ${req.body.repository.repo_name}:${req.body.push_data.tag} updated by ${req.body.push_data.pusher}`;
 
-  let channel = ''
   client.sendMessage(channel, msg, [req.body.repository.repo_url], (err) => {
     if (err) {
       console.log('Error while sending message to slack', err);
     }
     res.status(200).send('ok');
   });
+}
+
+app.post('/webhook', (req, res) => {
+  if (!req.body) {
+    return res.status(400).send();
+  }
+
+  processWebhook('', req, res);
+
 });
 
 app.post('/webhook/:channelName', (req, res) => {
@@ -43,14 +47,8 @@ app.post('/webhook/:channelName', (req, res) => {
     return res.status(400).send();
   }
 
-  let msg = `Docker Repository ${req.body.repository.repo_name}:${req.body.push_data.tag} updated by ${req.body.push_data.pusher}`;
+  processWebhook(channel, req, res);
 
-  client.sendMessage(channel, msg, [req.body.repository.repo_url], (err) => {
-    if (err) {
-      console.log('Error while sending message to slack', err);
-    }
-    res.status(200).send('ok');
-  });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
Newer Slack webhooks are tied to a channel by default. Adding this method allows you to post to `/webhook` and post to the channel the webhook is tied to.